### PR TITLE
Enabled fileExtensions to be configured (e.g. add .json) and added some instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,20 @@ brunch-js-minify-js-files
 
 Minify all JavaScript files after brunch compile has been done. Build to help minify files that brunch doesn't minify them or are not in the regular JavaScript folders (For example: files that are in the assets folder that you don't concatenate).
 
-Just add the folowing into your config.coffee file
+**Install**
+Add the plugin to `package.json`:
+```javascript
+dependencies": {
+  ...
+  "brunch-js-minify-js-files": "git://github.com/bogdanteodoru/brunch-js-minify-js-files.git"
+}
+```
+
+**Config**
+Just add the folowing into your `config.coffee`/`brunch-config.coffee` file:
 
 ```coffeescript
 minifyJsFiles:
-  active: true #if false it doesn't do anything ;)
+  active: true # if false it doesn't do anything ;)
+  fileExtensions: [".js", ".json"] # optional: when not specified, ".js" is used.
 ```

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -7,7 +7,7 @@ exists = fs.exists or path.exists
 
 module.exports = class minifyJsFiles
   brunchPlugin: yes
-  fileExtensions: ".js"
+  fileExtensions: null
   active: null
   appPath: ''
   options: null
@@ -18,6 +18,7 @@ module.exports = class minifyJsFiles
     @options =
       mangle: false
       compress: true
+    @fileExtensions = @config.minifyJsFiles.fileExtensions || ".js"
 
   onCompile: (generatedFiles) ->
     return unless fs.existsSync(@appPath)


### PR DESCRIPTION
As I wanted to use this brunch plugin to minify json files, I've added an (optional) method of specifying the fileExtensions to be minified.
